### PR TITLE
Responder channel interface and co-go migration

### DIFF
--- a/co/README.md
+++ b/co/README.md
@@ -1,0 +1,75 @@
+# Cogo
+
+A package for high-level concurrency patterns, in Go.
+
+## Usage
+
+### Parallelism
+
+Cogo offers two types of parallelism: implicit and explicit. Implicit parallelism means that Cogo will control how many goroutines are used to introduce parallelism, in contrast to explicit parallelism which gives control to the user.
+
+**Implicit Parallelism**
+
+In the following example, we use the `co.ForAll` function to loop over different iterators. Iterators are any value that makes sense to loop over: arrays, slices, maps, and integers. Cogo will use one goroutine per CPU core available and we cannot make any assumptions about which iteration will run on which goroutine. Calling `co.ForAll` will block until all iterations have finished running.
+
+```go
+// Fill an array of integers with random values
+xs := [10]int{}
+co.ForAll(xs, func(i int) {
+    xs[i] = rand.Intn(10)
+})
+
+// Map those random values to booleans
+ys := [10]bool{}
+co.ForAll(10, func(i int) {
+    ys[i] = xs[i] > 5
+})
+```
+
+In the following example, we use the `co.Begin` function to run distinct tasks. As before, Cogo will use one goroutine per CPU core available and map the different tasks over these goroutines. Calling `co.Begin` will block until all tasks have finished running.
+
+```go
+co.Begin(
+    func() {
+        log.Info("[task 1] when will this print?")
+    },
+    func() {
+        log.Info("[task 2] who knows?")
+    },
+    func() {
+        log.Info("[task 3] implicit parallelism is great!")
+    })
+```
+
+**Explicit Parallelism**
+
+In the following example, we use the `co.ParForAll` function to loop over different iterators. As with implicitly parallel loops, iterators are any value that makes sense to loop over: arrays, slices, maps, and integers. Unlike implicitly parallel loops, Cogo will use one goroutine per iteration, regardless of the number of CPU cores available. Calling `co.ParForAll` will block until all iterations have finished running.
+
+```go
+// Fill an array of integers with random values
+xs := [10]int{}
+co.ParForAll(xs, func(i int) {
+    xs[i] = rand.Intn(10)
+})
+
+// Map those random values to booleans
+ys := [10]bool{}
+co.ParForAll(10, func(i int) {
+    ys[i] = xs[i] > 5
+})
+```
+
+In the following example, we use the `co.ParBegin` function to run distinct tasks. Similar to the `co.ParForAll` function, Cogo will use one goroutine per task. Calling `co.ParBegin` will block until all tasks have finished running.
+
+```go
+co.ParBegin(
+    func() {
+        log.Info("[task 1] when will this print?")
+    },
+    func() {
+        log.Info("[task 2] who knows?")
+    },
+    func() {
+        log.Info("[task 3] explicit parallelism is great!")
+    })
+```

--- a/co/ch.go
+++ b/co/ch.go
@@ -1,0 +1,99 @@
+package co
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Forward all values from an input channels into an output channel. Forward is
+// blocking and panics when the input channel type do no match the output
+// channel.
+func Forward(done <-chan struct{}, in interface{}, out interface{}) {
+
+	// Ensure that all arguments are compatible types
+	if reflect.TypeOf(out).Kind() != reflect.Chan {
+		panic(fmt.Sprintf("cannot forward into type %v", reflect.TypeOf(out)))
+	}
+	if reflect.TypeOf(in).Kind() != reflect.Chan {
+		panic(fmt.Sprintf("cannot forward from type %v", reflect.TypeOf(in)))
+	}
+	if reflect.TypeOf(in).Elem().Kind() != reflect.TypeOf(out).Elem().Kind() {
+		panic(fmt.Sprintf("cannot forward from type %v to type %v", reflect.TypeOf(in), reflect.TypeOf(out)))
+	}
+
+	for {
+
+		// select {
+		// case <-done:
+		//     return
+		// case val, ok := <-in:
+		//     if !ok {
+		//         return
+		//     }
+		//     ...
+		// }
+		chosen, val, ok := reflect.Select([]reflect.SelectCase{
+			reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(done)},
+			reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(in)},
+		})
+		if chosen == 0 || !ok {
+			return
+		}
+
+		// select {
+		// case <-done:
+		//     return
+		// case out <-val:
+		// }
+		chosen, _, _ = reflect.Select([]reflect.SelectCase{
+			reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(done)},
+			reflect.SelectCase{Dir: reflect.SelectSend, Chan: reflect.ValueOf(out), Send: val},
+		})
+		if chosen == 0 {
+			return
+		}
+	}
+}
+
+// Merge multiple input channels into an output channel. Merge accepts a
+// channel of channels as input. For each of the channel read from the channel
+// of channels, all values are consumed and produced onto the output channel.
+// Merge is blocking and panics when the input channel types do no match the
+// output channel.
+func Merge(done <-chan struct{}, ins interface{}, out interface{}) {
+
+	// Ensure that all arguments are compatible types
+	if reflect.TypeOf(out).Kind() != reflect.Chan {
+		panic(fmt.Sprintf("cannot merge into type %v", reflect.TypeOf(out)))
+	}
+	if reflect.TypeOf(ins).Kind() != reflect.Chan {
+		panic(fmt.Sprintf("cannot merge from type %v", reflect.TypeOf(ins)))
+	}
+	if reflect.TypeOf(ins).Elem().Kind() != reflect.Chan {
+		panic(fmt.Sprintf("cannot merge from type %v", reflect.TypeOf(ins).Elem()))
+	}
+	if reflect.TypeOf(ins).Elem().Elem().Kind() != reflect.TypeOf(out).Elem().Kind() {
+		panic(fmt.Sprintf("cannot merge from type %T with elements of type", reflect.TypeOf(ins).Elem().Elem()))
+	}
+
+	for {
+
+		// select {
+		// case <-done:
+		//     return
+		// case in, ok := <-ins:
+		//     if !ok {
+		//         return
+		//     }
+		//     ...
+		// }
+		chosen, in, ok := reflect.Select([]reflect.SelectCase{
+			reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(done)},
+			reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ins)},
+		})
+		if chosen == 0 || !ok {
+			break
+		}
+		go Forward(done, in, out)
+	}
+}

--- a/co/ch_test.go
+++ b/co/ch_test.go
@@ -1,0 +1,163 @@
+package co_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/republicprotocol/co-go"
+)
+
+var _ = Describe("Channels", func() {
+
+	Context("when merging", func() {
+
+		It("should close the output channel when the done channel is closed", func() {
+			done := make(chan struct{})
+			ins := make(chan (chan int))
+			out := make(chan int)
+
+			go Merge(done, ins, out)
+
+			close(done)
+			<-out
+		})
+
+		It("should merge one input", func() {
+			done := make(chan struct{})
+			ins := make(chan (chan int))
+			out := make(chan int)
+
+			go Merge(done, ins, out)
+			go func() {
+				defer close(ins)
+				in := make(chan int)
+				ins <- in
+				for i := 0; i < 10; i++ {
+					in <- i
+				}
+			}()
+			for i := 0; i < 10; i++ {
+				Expect(<-out).Should(Equal(i))
+			}
+
+			close(done)
+			<-out
+		})
+
+		It("should merge multiple inputs", func() {
+			done := make(chan struct{})
+			ins := make(chan (chan int))
+			out := make(chan int)
+
+			go Merge(done, ins, out)
+			go func() {
+				defer close(ins)
+				for n := 0; n < 10; n++ {
+					in := make(chan int)
+					ins <- in
+					for i := 0; i < 10; i++ {
+						in <- i
+					}
+				}
+			}()
+			js := map[int]int{}
+			for i := 0; i < 10*10; i++ {
+				j := <-out
+				Expect(j).Should(BeNumerically(">=", 0))
+				Expect(j).Should(BeNumerically("<", 10))
+				js[j]++
+			}
+			for i := 0; i < 10; i++ {
+				Expect(js[i]).Should(Equal(10))
+			}
+
+			close(done)
+			<-out
+		})
+
+		Context("when using incompatible types", func() {
+			It("should panic", func() {
+				Expect(func() {
+					Merge(make(chan struct{}), make(chan (chan float32)), make(chan int))
+				}).Should(Panic())
+
+				Expect(func() {
+					Merge(make(chan struct{}), make(chan int), make(chan int))
+				}).Should(Panic())
+
+				Expect(func() {
+					Merge(make(chan struct{}), make(chan float32), make(chan int))
+				}).Should(Panic())
+
+				Expect(func() {
+					Merge(make(chan struct{}), make(chan (chan float32)), 0)
+				}).Should(Panic())
+
+				Expect(func() {
+					Merge(make(chan struct{}), 0, make(chan int))
+				}).Should(Panic())
+
+				Expect(func() {
+					Merge(make(chan struct{}), 0, 0)
+				}).Should(Panic())
+			})
+		})
+	})
+
+	Context("when forwarding", func() {
+
+		It("should close the output channel when the done channel is closed", func() {
+			done := make(chan struct{})
+			in := make(chan int)
+			out := make(chan int)
+
+			go Forward(done, in, out)
+
+			close(done)
+			<-out
+		})
+
+		It("should forward the input", func() {
+			done := make(chan struct{})
+			in := make(chan int)
+			out := make(chan int)
+
+			go Forward(done, in, out)
+			go func() {
+				defer close(in)
+				for i := 0; i < 10; i++ {
+					in <- i
+				}
+			}()
+			for i := 0; i < 10; i++ {
+				Expect(<-out).Should(Equal(i))
+			}
+
+			close(done)
+			<-out
+		})
+
+		Context("when using incompatible types", func() {
+			It("should panic", func() {
+				Expect(func() {
+					Forward(make(chan struct{}), make(chan (chan float32)), make(chan int))
+				}).Should(Panic())
+
+				Expect(func() {
+					Forward(make(chan struct{}), make(chan float32), make(chan int))
+				}).Should(Panic())
+
+				Expect(func() {
+					Forward(make(chan struct{}), make(chan (chan float32)), 0)
+				}).Should(Panic())
+
+				Expect(func() {
+					Forward(make(chan struct{}), 0, make(chan int))
+				}).Should(Panic())
+
+				Expect(func() {
+					Forward(make(chan struct{}), 0, 0)
+				}).Should(Panic())
+			})
+		})
+	})
+})

--- a/co/co.go
+++ b/co/co.go
@@ -1,0 +1,169 @@
+package co
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"sync"
+)
+
+// ParBegin multiple functions onto background goroutines. This function blocks
+// until all goroutines have terminated.
+func ParBegin(fs ...func()) {
+	var wg sync.WaitGroup
+	for _, f := range fs {
+		wg.Add(1)
+		go func(f func()) {
+			defer wg.Done()
+			f()
+		}(f)
+	}
+	wg.Wait()
+}
+
+// ParForAll uses an iterator to execute an iterand function on each value
+// returned by the iterator, using a background goroutine for each iteration.
+// An iterator can be an array, a slice, a map, or an int. For arrays, and
+// slices, the iterand function must accept an int index as the only argument.
+// For maps, the iterand function must accept a key as the only argument. For
+// ints, the iterand function must accept an int, in the range [0, n), as the
+// only argument. This function blocks until all goroutines have terminated.
+func ParForAll(iter interface{}, f interface{}) {
+	funTy := reflect.TypeOf(f)
+	if funTy.Kind() != reflect.Func {
+		panic(fmt.Sprintf("parforall error: expected iterator got %T", iter))
+	}
+	fun := reflect.ValueOf(f)
+
+	switch reflect.TypeOf(iter).Kind() {
+
+	case reflect.Array, reflect.Slice:
+		it := reflect.ValueOf(iter)
+		numGoroutines := it.Len()
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+		for i := 0; i < numGoroutines; i++ {
+			go func(i int) {
+				defer wg.Done()
+				fun.Call([]reflect.Value{reflect.ValueOf(i)})
+			}(i)
+		}
+		wg.Wait()
+
+	case reflect.Map:
+		it := reflect.ValueOf(iter)
+		keys := it.MapKeys()
+		numGoroutines := len(keys)
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+		for i := 0; i < numGoroutines; i++ {
+			go func(i int) {
+				defer wg.Done()
+				fun.Call([]reflect.Value{keys[i]})
+			}(i)
+		}
+		wg.Wait()
+
+	case reflect.Int:
+		numGoroutines := int(reflect.ValueOf(iter).Int())
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+		for i := 0; i < numGoroutines; i++ {
+			go func(i int) {
+				defer wg.Done()
+				fun.Call([]reflect.Value{reflect.ValueOf(i)})
+			}(i)
+		}
+		wg.Wait()
+
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		panic(fmt.Sprintf("parforall error: expected int got %T", iter))
+
+	default:
+		panic(fmt.Sprintf("parforall error: expected iterator got %T", iter))
+	}
+
+}
+
+// ForAll uses an iterator to execute an iterand function on each value
+// returned by the iterator, using a background goroutine for CPU and
+// distributing the iterands evenly across each goroutine. An iterator can be
+// an array, a slice, a map, or an int. For arrays, and slices, the iterand
+// function must accept an int index as the only argument. For maps, the
+// iterand function must accept a key as the only argument. For ints, the
+// iterand function must accept an int, in the range [0, n), as the only
+// argument. This function blocks until all goroutines have terminated.
+func ForAll(iter interface{}, f interface{}) {
+	funTy := reflect.TypeOf(f)
+	if funTy.Kind() != reflect.Func {
+		panic(fmt.Sprintf("forall error: expected iterator got %T", iter))
+	}
+	fun := reflect.ValueOf(f)
+
+	switch reflect.TypeOf(iter).Kind() {
+
+	case reflect.Array, reflect.Slice:
+		it := reflect.ValueOf(iter)
+		num := it.Len()
+		numGoroutines := runtime.NumCPU()
+		numPerGoroutine := num/numGoroutines + 1
+
+		var wg sync.WaitGroup
+		for i := 0; i < num; i += numPerGoroutine {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				for j := i; j < i+numPerGoroutine && j < num; j++ {
+					fun.Call([]reflect.Value{reflect.ValueOf(j)})
+				}
+			}(i)
+		}
+		wg.Wait()
+
+	case reflect.Map:
+		it := reflect.ValueOf(iter)
+		keys := it.MapKeys()
+		num := len(keys)
+		numGoroutines := runtime.NumCPU()
+		numPerGoroutine := num/numGoroutines + 1
+
+		var wg sync.WaitGroup
+		for i := 0; i < num; i += numPerGoroutine {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				for j := i; j < i+numPerGoroutine && j < num; j++ {
+					fun.Call([]reflect.Value{keys[j]})
+				}
+			}(i)
+		}
+		wg.Wait()
+
+	case reflect.Int:
+		num := int(reflect.ValueOf(iter).Int())
+		numGoroutines := runtime.NumCPU()
+		numPerGoroutine := num/numGoroutines + 1
+
+		var wg sync.WaitGroup
+		for i := 0; i < num; i += numPerGoroutine {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				for j := i; j < i+numPerGoroutine && j < num; j++ {
+					fun.Call([]reflect.Value{reflect.ValueOf(j)})
+				}
+			}(i)
+		}
+		wg.Wait()
+
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		panic(fmt.Sprintf("forall error: expected int got %T", iter))
+
+	default:
+		panic(fmt.Sprintf("forall error: expected iterator got %T", iter))
+	}
+
+}

--- a/co/co_suite_test.go
+++ b/co/co_suite_test.go
@@ -1,0 +1,13 @@
+package co_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCogo(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cogo Suite")
+}

--- a/co/co_test.go
+++ b/co/co_test.go
@@ -1,0 +1,173 @@
+package co_test
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/republicprotocol/co-go"
+)
+
+var _ = Describe("Concurrency", func() {
+
+	Context("when using parbegin", func() {
+
+		It("should block until all goroutines terminate", func() {
+			start := time.Now()
+			ParBegin(func() {
+				time.Sleep(1 * time.Second)
+			})
+			end := time.Now()
+			Expect(end.Sub(start).Seconds() >= 1).Should(BeTrue())
+		})
+
+		It("should wait for multiple functions to end", func() {
+			start := time.Now()
+			ParBegin(func() {
+				time.Sleep(250 * time.Millisecond)
+			}, func() {
+				time.Sleep(500 * time.Millisecond)
+			}, func() {
+				time.Sleep(750 * time.Millisecond)
+			}, func() {
+				time.Sleep(1 * time.Second)
+			})
+			end := time.Now()
+			Expect(end.Sub(start).Seconds() >= 1).Should(BeTrue())
+		})
+
+	})
+
+	Context("when using parforall loops", func() {
+
+		It("should iterate over arrays", func() {
+			num := int64(0)
+			xs := [10]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+			ParForAll(xs, func(i int) {
+				Expect(xs[i]).Should(Equal(i + 1))
+				atomic.AddInt64(&num, 1)
+			})
+			Expect(num).Should(Equal(int64(10)))
+		})
+
+		It("should iterate over slices", func() {
+			num := int64(0)
+			xs := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+			ParForAll(xs[:], func(i int) {
+				Expect(xs[i]).Should(Equal(i + 1))
+				atomic.AddInt64(&num, 1)
+			})
+			Expect(num).Should(Equal(int64(10)))
+		})
+
+		It("should over maps", func() {
+			num := int64(0)
+			xs := map[string]int{
+				"1": 1,
+				"2": 2,
+				"3": 3,
+			}
+			ParForAll(xs, func(key string) {
+				switch key {
+				case "1":
+					Expect(xs[key]).Should(Equal(1))
+				case "2":
+					Expect(xs[key]).Should(Equal(2))
+				case "3":
+					Expect(xs[key]).Should(Equal(3))
+				default:
+					panic(fmt.Sprintf("parforall error: invalid key found in map %v", key))
+				}
+				atomic.AddInt64(&num, 1)
+			})
+			Expect(num).Should(Equal(int64(3)))
+		})
+
+		It("should iterate over ints", func(done Done) {
+			defer close(done)
+
+			n := int64(0)
+			xs := make(chan int, 10)
+			ParForAll(10, func(i int) {
+				xs <- (i + 1)
+				atomic.AddInt64(&n, 1)
+			})
+			close(xs)
+
+			for i := range xs {
+				Expect(i).Should(BeNumerically(">=", 1))
+				Expect(i).Should(BeNumerically("<=", 10))
+			}
+			Expect(n).Should(Equal(int64(10)))
+		})
+
+	})
+
+	Context("when using forall loops", func() {
+
+		It("should iterate over arrays", func() {
+			num := int64(0)
+			xs := [10]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+			ForAll(xs, func(i int) {
+				Expect(xs[i]).Should(Equal(i + 1))
+				atomic.AddInt64(&num, 1)
+			})
+			Expect(num).Should(Equal(int64(10)))
+		})
+
+		It("should iterate over slices", func() {
+			num := int64(0)
+			xs := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+			ForAll(xs[:], func(i int) {
+				Expect(xs[i]).Should(Equal(i + 1))
+				atomic.AddInt64(&num, 1)
+			})
+			Expect(num).Should(Equal(int64(10)))
+		})
+
+		It("should over maps", func() {
+			num := int64(0)
+			xs := map[string]int{
+				"1": 1,
+				"2": 2,
+				"3": 3,
+			}
+			ForAll(xs, func(key string) {
+				switch key {
+				case "1":
+					Expect(xs[key]).Should(Equal(1))
+				case "2":
+					Expect(xs[key]).Should(Equal(2))
+				case "3":
+					Expect(xs[key]).Should(Equal(3))
+				default:
+					panic(fmt.Sprintf("forall error: invalid key found in map %v", key))
+				}
+				atomic.AddInt64(&num, 1)
+			})
+			Expect(num).Should(Equal(int64(3)))
+		})
+
+		It("should iterate over ints", func(done Done) {
+			defer close(done)
+
+			n := int64(0)
+			xs := make(chan int, 10)
+			ForAll(10, func(i int) {
+				xs <- (i + 1)
+				atomic.AddInt64(&n, 1)
+			})
+			close(xs)
+
+			for i := range xs {
+				Expect(i).Should(BeNumerically(">=", 1))
+				Expect(i).Should(BeNumerically("<=", 10))
+			}
+			Expect(n).Should(Equal(int64(10)))
+		})
+
+	})
+
+})

--- a/examples/maxnum/player.go
+++ b/examples/maxnum/player.go
@@ -40,7 +40,7 @@ func (player *Player) Reduce(message phi.Message) phi.Message {
 			}
 			if uint(len(player.seen)) == player.players {
 				done := Done{player: player.id, max: player.currentMax}
-				return phi.MessageBatch{Messages: []phi.Message{message, done}}
+				return phi.Messages{Messages: []phi.Message{message, done}}
 			}
 			return message
 		}

--- a/examples/maxnum/player.go
+++ b/examples/maxnum/player.go
@@ -40,7 +40,7 @@ func (player *Player) Reduce(message phi.Message) phi.Message {
 			}
 			if uint(len(player.seen)) == player.players {
 				done := Done{player: player.id, max: player.currentMax}
-				return phi.Messages{Messages: []phi.Message{message, done}}
+				return phi.Messages{message, done}
 			}
 			return message
 		}

--- a/examples/maxnum/router.go
+++ b/examples/maxnum/router.go
@@ -97,7 +97,7 @@ func (router *Router) sendAsync(player phi.Task, message phi.Message) {
 			responder, ok = player.Send(message)
 		}
 		messages := <-responder
-		for _, m := range messages.Messages {
+		for _, m := range messages {
 			_, ok = router.task.Send(m)
 			// Ensure that the responses get received
 			for !ok {

--- a/examples/pingpong/pingpong.go
+++ b/examples/pingpong/pingpong.go
@@ -44,12 +44,17 @@ func (pinger *PerpetualPinger) Reduce(message phi.Message) phi.Message {
 }
 
 func (pinger *PerpetualPinger) pingAsync() {
+	responder, ok := pinger.ponger.Send(Ping{})
+	if !ok {
+		panic("failed to send ping")
+	}
 	go func() {
-		pong, ok := pinger.ponger.SendSync(Ping{})
-		if !ok {
-			panic("failed to send ping")
+		for m := range responder {
+			_, ok := pinger.task.Send(m)
+			if !ok {
+				panic("failed to receive pong")
+			}
 		}
-		pinger.task.Send(pong)
 	}()
 }
 

--- a/phi.go
+++ b/phi.go
@@ -1,90 +1,156 @@
 package phi
 
-import "context"
+import (
+	"context"
+)
 
+// Message represents a message that is sent between tasks for communication.
+// It is an enum style interface where a struct can be made a variant of the
+// enum by implementing the interface.
 type Message interface {
 	IsMessage()
 }
 
-type MessageSync struct {
-	message   Message
-	responder chan Message
+// messageWithResponder is a `Message` wrapper that also contains a channel
+// where a response can be written.
+type messageWithResponder struct {
+	// The message being sent.
+	message Message
+
+	// The responder channel where the task will write its response.
+	responder chan Messages
 }
 
-type MessageBatch struct {
+// Messages is a collection of messages. Note that reducers will never receive
+// a `Messages` type because they will always be flattened before being
+// processed. If a task needs to respond with more than one message, and it is
+// important that these messages are processed together, then a custom
+// container type should be created and handled appropriately in the reducer.
+type Messages struct {
 	Messages []Message
 }
 
-func (MessageBatch) IsMessage() {}
+// IsMessage implements the Message interface.
+func (Messages) IsMessage() {}
 
+// Runner represents something that can be run.
 type Runner interface {
+	// Run by convention will be blocking. The context should be used to signal
+	// the task to terminate.
 	Run(context.Context)
 }
 
+// Sender represents something that can be sent messages.
 type Sender interface {
-	Send(Message) bool
-	SendSync(Message) (Message, bool)
+	// Send takes a message and returns a channel where the response will be
+	// written and also a boolean that indicates if the send was successful.
+	Send(Message) (<-chan Messages, bool)
 }
 
+// Task is the intersection of the `Runner` and `Sender` interfaces. It
+// represents an entity that (when running) can be sent messages and upon
+// receipt of these messages performs internal logic (which often involves
+// sending messages to other tasks) and can also return response messages.
 type Task interface {
 	Runner
 	Sender
 }
 
+// Reducer represents something that can receive a message and provide a
+// corresponding result.
 type Reducer interface {
 	Reduce(Message) Message
 }
 
+// task is a basic implementation for a `Task`.
 type task struct {
-	reducer   Reducer
-	input     chan Message
-	inputSync chan MessageSync
-	done      chan struct{}
+	// The reducer for message handling logic.
+	reducer Reducer
+
+	// The buffered channel that incoming messages are written to.
+	input chan messageWithResponder
 }
 
+// NewTask returns a new task with the given reducer and buffer capacity. The
+// buffer capacity is the number of messages that can be buffered for
+// processing before the task can no longer accept more messages (until space
+// in the buffer is freed up by processing messages in the buffer).
 func NewTask(reducer Reducer, cap int) Task {
 	return &task{
-		reducer:   reducer,
-		input:     make(chan Message, cap),
-		inputSync: make(chan MessageSync, cap),
-		done:      make(chan struct{}),
+		reducer: reducer,
+		input:   make(chan messageWithResponder, cap),
 	}
 }
 
+// Run implements the `Runner` interface (in order to implement the `Task`
+// interface). This function blocks. The task will continue to run until it is
+// signalled to terminate by the context.
 func (task *task) Run(ctx context.Context) {
-	defer close(task.done)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case message := <-task.input:
-			task.reducer.Reduce(message)
-		case message := <-task.inputSync:
-			message.responder <- task.reducer.Reduce(message.message)
+			message.responder <- task.reduce(flatten(message.message))
+			close(message.responder)
 		}
 	}
 }
 
-func (task *task) Send(message Message) bool {
+// Send implements the `Sender` interface (in order to implement the `Task`
+// interface). It returns a channel to which the (possibly nil) response will
+// be written, and a bool indicating whether the message was able to be sent;
+// true indicates the message was sent, and false indicates that the task
+// currently has a full buffer and won't accept the message. In the latter case
+// the returned channel will be nil.
+func (task *task) Send(message Message) (<-chan Messages, bool) {
+	responder := make(chan Messages, 1)
+	m := messageWithResponder{message: message, responder: responder}
 	select {
-	case task.input <- message:
-		return true
-	default:
-		return false
-	}
-}
-
-func (task *task) SendSync(message Message) (Message, bool) {
-	responder := make(chan Message, 1)
-	select {
-	case task.inputSync <- MessageSync{message, responder}:
-		select {
-		case <-task.done:
-			return nil, false
-		case response := <-responder:
-			return response, true
-		}
+	case task.input <- m:
+		return responder, true
 	default:
 		return nil, false
+	}
+}
+
+// reduce will handle the reduction of a given message for a task. It is
+// assumed that the message is flattened. It will always return a `Messages`
+// type which contains the responses of the reducre for the given emssage(s).
+// The returned `Messages` is flattened.
+func (task *task) reduce(message Message) Messages {
+	messages := Messages{Messages: []Message{}}
+	switch message := message.(type) {
+	case Messages:
+		for _, msg := range message.Messages {
+			messages.Messages = append(messages.Messages, task.reducer.Reduce(msg))
+		}
+	default:
+		messages.Messages = append(messages.Messages, task.reducer.Reduce(message))
+	}
+	return flatten(messages).(Messages)
+}
+
+// flatten takes a message and effectively flattens it out to depth 1, where
+// the depth is determined by the level of nested Messages. If `flatten`
+// receives a message that is not a `Messages`, it will return the same
+// message. Otherwise, it will return a `Messages` type where the internal list
+// of messages contain no `Messages`; these will be flattened out.
+func flatten(message Message) Message {
+	switch message := message.(type) {
+	case Messages:
+		msgs := []Message{}
+		for _, msg := range message.Messages {
+			m := flatten(msg)
+			switch m := m.(type) {
+			case Messages:
+				msgs = append(msgs, m.Messages...)
+			default:
+				msgs = append(msgs, m)
+			}
+		}
+		return Messages{Messages: msgs}
+	default:
+		return message
 	}
 }

--- a/phi.go
+++ b/phi.go
@@ -116,7 +116,7 @@ func (task *task) Send(message Message) (<-chan Messages, bool) {
 
 // reduce will handle the reduction of a given message for a task. It is
 // assumed that the message is flattened. It will always return a `Messages`
-// type which contains the responses of the reducre for the given emssage(s).
+// type which contains the responses of the reducer for the given message(s).
 // The returned `Messages` is flattened.
 func (task *task) reduce(message Message) Messages {
 	messages := Messages{Messages: []Message{}}


### PR DESCRIPTION
This PR changes the `Task` interface and migrates `co-go` to be a subpackage of the repository.

### Motivation
After the first design iteration, using the framework in the examples brought some possible design changes to light. The main driver for change was one example doing batch message handling, which was not application specific and so it was decided that this logic should be at the library level. Implementing this made it apparent that some interface changes would be beneficial.

Regarding `co-go`, the idea is that this repository will contain all of our concurrency utilities.

### Changes
Originally there were separate `Send` and `SendSync` functions, with the latter being used for synchronous communication by blocking on the function call and waiting for the return value. The former would not block but would provide no handle to any response. Now, these two functions are encapsulated in the single `Send` function, which now returns a channel to which any responses will be written. Additionally, `Task`s used to expose a `Terminate` function allowing anyone to terminate a task. This has been removed in favour of `Task` termination being the responsibility of the owner of the `Task`, through the `Context`.

There is now a `co` subpackage in the `phi` package.