### PR TITLE
Reducer has reference to parent task

### DIFF
--- a/examples/maxnum/main.go
+++ b/examples/maxnum/main.go
@@ -49,7 +49,6 @@ func main() {
 	}
 	router, results := NewRouter(ringTopology(numPlayers), playerMap)
 	routerTask := phi.NewTask(&router, int(numPlayers))
-	router.SetTask(routerTask)
 
 	// Start the tasks
 	done := context.Background()

--- a/examples/maxnum/player.go
+++ b/examples/maxnum/player.go
@@ -27,7 +27,7 @@ func (player *Player) ID() uint {
 }
 
 // Reduce implements the `phi.Reducer` interface.
-func (player *Player) Reduce(message phi.Message) phi.Message {
+func (player *Player) Reduce(_ phi.Task, message phi.Message) phi.Message {
 	switch message := message.(type) {
 	case Begin:
 		return PlayerNum{from: player.id, player: player.id, num: player.num}

--- a/examples/pingpong/main.go
+++ b/examples/pingpong/main.go
@@ -10,11 +10,10 @@ import (
 
 func main() {
 	// Create the pinger and ponger tasks
-	pinger := NewPerpetualPinger()
-	pingerTask := phi.NewTask(&pinger, 1)
 	ponger := NewPonger()
 	pongerTask := phi.NewTask(&ponger, 1)
-	pinger.CompleteSetup(pongerTask, pingerTask)
+	pinger := NewPerpetualPinger(pongerTask)
+	pingerTask := phi.NewTask(&pinger, 1)
 
 	// Run the tasks
 	done := context.Background()

--- a/phi.go
+++ b/phi.go
@@ -57,7 +57,7 @@ type Task interface {
 // Reducer represents something that can receive a message and provide a
 // corresponding result.
 type Reducer interface {
-	Reduce(Message) Message
+	Reduce(Task, Message) Message
 }
 
 // task is a basic implementation for a `Task`.
@@ -121,10 +121,10 @@ func (task *task) reduce(message Message) Messages {
 	switch message := message.(type) {
 	case Messages:
 		for _, msg := range message {
-			messages = append(messages, task.reducer.Reduce(msg))
+			messages = append(messages, task.reducer.Reduce(task, msg))
 		}
 	default:
-		messages = append(messages, task.reducer.Reduce(message))
+		messages = append(messages, task.reducer.Reduce(task, message))
 	}
 	return flatten(messages).(Messages)
 }

--- a/phi.go
+++ b/phi.go
@@ -55,7 +55,8 @@ type Task interface {
 }
 
 // Reducer represents something that can receive a message and provide a
-// corresponding result.
+// corresponding result. The `Task` argument is the parent task of the reducer,
+// and can be used as a handle to send messages to a reducer's own task.
 type Reducer interface {
 	Reduce(Task, Message) Message
 }


### PR DESCRIPTION
This PR changes the `Reducer` interface so that takes a reference to its own parent task.

### Motivation
When a task/reducer uses the `sendAsync` pattern (asynchronously sending a message to a task and waiting for the response) it needs to call its parent task's `Send` function, and therefore needs a reference to this task. This lead to awkward usage where after creating a reducer and its associated task, it would then be necessary to update the reducer by giving it a reference to the task.

### Changes
The `Reducer` interface has changed so that `Reduce` now takes a task as an argument, which represents the reducer's parent task. When implementing `Reduce` this reference to self is now automatically available and doesn't require any extra setup.