### PR TITLE
Add message sink in router

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  core: ren/circleci-orbs@dev:first
 executors:
   go_exec:
     docker:


### PR DESCRIPTION
We found that sometimes when a router receives a message, we do not actually want to send it anywhere (for example, not sending duplicate messages). This functionality was achieved by updating the router logic; returning a nil sender from `Resolve` signifies that a message should not be sent anywhere.