### PR TITLE
Async message passing

### DIFF
--- a/examples/lb/lb.go
+++ b/examples/lb/lb.go
@@ -11,7 +11,7 @@ type LB struct {
 	id int
 }
 
-// Handle implements the `phi.Handlerr` interface. We simulate a slow task by
+// Handle implements the `phi.Handler` interface. We simulate a slow task by
 // simply sleeping for a time before returning.
 func (LB) Handle(_ phi.Task, m phi.Message) {
 	if m, ok := m.(Init); ok {

--- a/examples/lb/lb.go
+++ b/examples/lb/lb.go
@@ -11,9 +11,11 @@ type LB struct {
 	id int
 }
 
-// Reduce implements the `phi.Reducer` interface. We simulate a slow task by
+// Handle implements the `phi.Handlerr` interface. We simulate a slow task by
 // simply sleeping for a time before returning.
-func (LB) Reduce(_ phi.Task, _ phi.Message) phi.Message {
-	time.Sleep(time.Second)
-	return Done{}
+func (LB) Handle(_ phi.Task, m phi.Message) {
+	if m, ok := m.(Init); ok {
+		time.Sleep(time.Second)
+		m.Responder <- Done{}
+	}
 }

--- a/examples/lb/lb.go
+++ b/examples/lb/lb.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/renproject/phi"
@@ -14,8 +15,10 @@ type LB struct {
 // Handle implements the `phi.Handler` interface. We simulate a slow task by
 // simply sleeping for a time before returning.
 func (LB) Handle(_ phi.Task, m phi.Message) {
-	if m, ok := m.(Init); ok {
-		time.Sleep(time.Second)
-		m.Responder <- Done{}
+	init, ok := m.(Init)
+	if !ok {
+		panic(fmt.Errorf("unexpected message type=%T", m))
 	}
+	time.Sleep(time.Second)
+	init.Responder <- Done{}
 }

--- a/examples/lb/main.go
+++ b/examples/lb/main.go
@@ -39,7 +39,7 @@ func main() {
 	// Send requests to the user
 	start := time.Now()
 	for i := 0; i < n; i++ {
-		_, ok := userTask.Send(Init{})
+		ok := userTask.Send(Init{Responder: make(chan phi.Message, 1)})
 		if !ok {
 			panic("message should send correctly")
 		}

--- a/examples/lb/message.go
+++ b/examples/lb/message.go
@@ -1,13 +1,18 @@
 package main
 
+import "github.com/renproject/phi"
+
 // Init is a message that signals a worker to start work.
-type Init struct{}
+type Init struct {
+	Responder chan phi.Message
+}
 
 // IsMessage implements the `phi.Message` interface.
 func (Init) IsMessage() {}
 
 // Done is a message to signal that a worker is done.
-type Done struct{}
+type Done struct {
+}
 
 // IsMessage implements the `phi.Message` interface.
 func (Done) IsMessage() {}

--- a/examples/lb/message.go
+++ b/examples/lb/message.go
@@ -11,7 +11,7 @@ type Init struct {
 func (Init) IsMessage() {}
 
 // Done is a message to signal that a worker is done.
-type Done struct {
+type Done struct{}
 }
 
 // IsMessage implements the `phi.Message` interface.

--- a/examples/lb/message.go
+++ b/examples/lb/message.go
@@ -12,7 +12,6 @@ func (Init) IsMessage() {}
 
 // Done is a message to signal that a worker is done.
 type Done struct{}
-}
 
 // IsMessage implements the `phi.Message` interface.
 func (Done) IsMessage() {}

--- a/examples/lb/user.go
+++ b/examples/lb/user.go
@@ -28,13 +28,13 @@ func NewUser(lb phi.Sender, resultsNeeded int) (User, <-chan struct{}) {
 	}, done
 }
 
-// Reduce implements the `phi.Reducer` interface. Upon receiving an `Init`
+// Handle implements the `phi.Handler` interface. Upon receiving an `Init`
 // message, the user will then send this to the load balancer. Once receiving
 // the corresponding result, it will update the number of results it has seen.
 // Once it has seen `resultsNeeded` responses, it will close the done channel,
 // signalling that it has finished.
-func (user *User) Reduce(self phi.Task, message phi.Message) phi.Message {
-	switch message.(type) {
+func (user *User) Handle(self phi.Task, message phi.Message) {
+	switch message := message.(type) {
 	case Init:
 		user.sendAsync(self, message)
 	case Done:
@@ -45,28 +45,24 @@ func (user *User) Reduce(self phi.Task, message phi.Message) phi.Message {
 	default:
 		panic(fmt.Sprintf("unexpected message type %T", message))
 	}
-
-	return nil
 }
 
 // sendAsync sends a message and asynchronously waits for the response. It will
 // ensure that the message is sent.
-func (user *User) sendAsync(self phi.Task, message phi.Message) {
+func (user *User) sendAsync(self phi.Task, init Init) {
 	go func() {
-		responder, ok := user.lb.Send(message)
+		ok := user.lb.Send(init)
 		// Ensure that the message is sent
 		for !ok {
 			time.Sleep(10 * time.Millisecond)
-			responder, ok = user.lb.Send(message)
+			ok = user.lb.Send(init)
 		}
-		messages := <-responder
-		for _, m := range messages {
-			_, ok = self.Send(m)
-			// Ensure that the responses get received
-			for !ok {
-				time.Sleep(10 * time.Millisecond)
-				_, ok = self.Send(m)
-			}
+		m := <-init.Responder
+		ok = self.Send(m)
+		// Ensure that the responses get received
+		for !ok {
+			time.Sleep(10 * time.Millisecond)
+			ok = self.Send(m)
 		}
 	}()
 }

--- a/examples/maxnum/main.go
+++ b/examples/maxnum/main.go
@@ -61,7 +61,7 @@ func main() {
 	go routerTask.Run(ctx)
 
 	// Send the initial message
-	routerTask.Send(Begin{})
+	routerTask.Send(BeginRouter{})
 
 	// Read and check the result
 	result := <-results

--- a/examples/maxnum/message.go
+++ b/examples/maxnum/message.go
@@ -1,7 +1,16 @@
 package main
 
-// Begin is a signal for the router start the execution.
-type Begin struct{}
+import "github.com/renproject/phi"
+
+// BeginRouter is a signal for the router start the execution.
+type BeginRouter struct{}
+
+func (BeginRouter) IsMessage() {}
+
+// Begin is a signal for the router start the execution of player.
+type Begin struct {
+	Responder chan phi.Message
+}
 
 // IsMessage implements the `phi.Message` interface.
 func (Begin) IsMessage() {}
@@ -10,6 +19,7 @@ func (Begin) IsMessage() {}
 // what numbers each player has.
 type PlayerNum struct {
 	from, player, num uint
+	Responder         chan phi.Message
 }
 
 // IsMessage implements the `phi.Message` interface.

--- a/examples/maxnum/player.go
+++ b/examples/maxnum/player.go
@@ -26,11 +26,11 @@ func (player *Player) ID() uint {
 	return player.id
 }
 
-// Reduce implements the `phi.Reducer` interface.
-func (player *Player) Reduce(_ phi.Task, message phi.Message) phi.Message {
+// Handle implements the `phi.Handler` interface.
+func (player *Player) Handle(_ phi.Task, message phi.Message) {
 	switch message := message.(type) {
 	case Begin:
-		return PlayerNum{from: player.id, player: player.id, num: player.num}
+		message.Responder <- PlayerNum{from: player.id, player: player.id, num: player.num}
 	case PlayerNum:
 		if _, ok := player.seen[message.player]; !ok {
 			player.seen[message.player] = message.num
@@ -40,11 +40,11 @@ func (player *Player) Reduce(_ phi.Task, message phi.Message) phi.Message {
 			}
 			if uint(len(player.seen)) == player.players {
 				done := Done{player: player.id, max: player.currentMax}
-				return phi.Messages{message, done}
+				message.Responder <- phi.Messages{message, done}
 			}
-			return message
+			message.Responder <- message
 		}
-		return nil
+		message.Responder <- phi.Messages{}
 	default:
 		panic(fmt.Sprintf("unexpected message type %T", message))
 	}

--- a/examples/maxnum/router.go
+++ b/examples/maxnum/router.go
@@ -44,21 +44,28 @@ func NewRouter(routeTable map[uint][]uint, players map[uint]phi.Task) (Router, c
 	}, resultWriter
 }
 
-// Reduce implements the `phi.Reducer` interface.
-func (router *Router) Reduce(self phi.Task, message phi.Message) phi.Message {
+// Handle implements the `phi.Handler` interface.
+func (router *Router) Handle(self phi.Task, message phi.Message) {
 	// A nil message means that nothing needs to be routed
 	if message == nil || router.terminated {
-		return nil
+		return
 	}
 
 	switch message := message.(type) {
-	case Begin:
+	case BeginRouter:
 		for _, player := range router.players {
-			router.sendAsync(self, player, message)
+			responder := make(chan phi.Message, 1)
+			router.sendAsync(self, player, Begin{Responder: responder}, responder)
 		}
 	case PlayerNum:
 		for _, to := range router.routeTable[message.from] {
-			router.sendAsync(self, router.players[to], message)
+			responder := make(chan phi.Message, 1)
+			router.sendAsync(self, router.players[to], PlayerNum{
+				from:      message.from,
+				player:    message.player,
+				num:       message.num,
+				Responder: responder,
+			}, responder)
 		}
 	case Done:
 		router.resultsSeen++
@@ -76,27 +83,34 @@ func (router *Router) Reduce(self phi.Task, message phi.Message) phi.Message {
 	default:
 		panic(fmt.Sprintf("unexpected message type %T", message))
 	}
-
-	return nil
 }
 
 // sendAsync sends a message and asynchronously waits for the response. It will
 // ensure that the message is sent.
-func (router *Router) sendAsync(self phi.Task, player phi.Task, message phi.Message) {
+func (router *Router) sendAsync(self phi.Task, player phi.Task, message phi.Message, responder chan phi.Message) {
 	go func() {
-		responder, ok := player.Send(message)
+		ok := player.Send(message)
 		// Ensure that the message is sent
 		for !ok {
 			time.Sleep(10 * time.Millisecond)
-			responder, ok = player.Send(message)
+			ok = player.Send(message)
 		}
-		messages := <-responder
-		for _, m := range messages {
-			_, ok = self.Send(m)
+		m := <-responder
+		if messages, ok := m.(phi.Messages); ok {
+			for _, m := range messages {
+				ok = self.Send(m)
+				// Ensure that the responses get received
+				for !ok {
+					time.Sleep(10 * time.Millisecond)
+					ok = self.Send(m)
+				}
+			}
+		} else {
+			ok = self.Send(m)
 			// Ensure that the responses get received
 			for !ok {
 				time.Sleep(10 * time.Millisecond)
-				_, ok = self.Send(m)
+				ok = self.Send(m)
 			}
 		}
 	}()

--- a/examples/pingpong/message.go
+++ b/examples/pingpong/message.go
@@ -19,7 +19,7 @@ type Ping struct {
 func (Ping) IsMessage() {}
 
 // Pong represents a pong.
-type Pong struct {
+type Pong struct{}
 }
 
 // IsMessage implements the `phi.Message` interface.

--- a/examples/pingpong/message.go
+++ b/examples/pingpong/message.go
@@ -1,19 +1,26 @@
 package main
 
+import "github.com/renproject/phi"
+
 // Begin signals the pinger to start by sending a ping to the ponger.
-type Begin struct{}
+type Begin struct {
+	Responder chan phi.Message
+}
 
 // IsMessage implements the `phi.Message` interface.
 func (Begin) IsMessage() {}
 
 // Ping represents a ping.
-type Ping struct{}
+type Ping struct {
+	Responder chan phi.Message
+}
 
 // IsMessage implements the `phi.Message` interface.
 func (Ping) IsMessage() {}
 
 // Pong represents a pong.
-type Pong struct{}
+type Pong struct {
+}
 
 // IsMessage implements the `phi.Message` interface.
 func (Pong) IsMessage() {}

--- a/examples/pingpong/message.go
+++ b/examples/pingpong/message.go
@@ -20,7 +20,6 @@ func (Ping) IsMessage() {}
 
 // Pong represents a pong.
 type Pong struct{}
-}
 
 // IsMessage implements the `phi.Message` interface.
 func (Pong) IsMessage() {}

--- a/examples/router/dest.go
+++ b/examples/router/dest.go
@@ -16,11 +16,11 @@ func NewDestA(name string) DestA {
 	return DestA{name: name}
 }
 
-// Reduce implements the `phi.Reducer` interface.
-func (destA *DestA) Reduce(_ phi.Task, message phi.Message) phi.Message {
-	switch message.(type) {
+// Handle implements the `phi.Handler` interface.
+func (destA *DestA) Handle(_ phi.Task, message phi.Message) {
+	switch m := message.(type) {
 	case MessageA:
-		return Response{msg: destA.name}
+		m.Responder <- Response{msg: destA.name}
 	default:
 		panic(fmt.Sprintf("unexpected message type %T", message))
 	}
@@ -36,11 +36,11 @@ func NewDestB(name string) DestB {
 	return DestB{name: name}
 }
 
-// Reduce implements the `phi.Reducer` interface.
-func (destB *DestB) Reduce(_ phi.Task, message phi.Message) phi.Message {
-	switch message.(type) {
+// Handle implements the `phi.Handler` interface.
+func (destB *DestB) Handle(_ phi.Task, message phi.Message) {
+	switch m := message.(type) {
 	case MessageB:
-		return Response{msg: destB.name}
+		m.Responder <- Response{msg: destB.name}
 	default:
 		panic(fmt.Sprintf("unexpected message type %T", message))
 	}
@@ -56,11 +56,11 @@ func NewDestC(name string) DestC {
 	return DestC{name: name}
 }
 
-// Reduce implements the `phi.Reducer` interface.
-func (destC *DestC) Reduce(_ phi.Task, message phi.Message) phi.Message {
-	switch message.(type) {
+// Handle implements the `phi.Handler` interface.
+func (destC *DestC) Handle(_ phi.Task, message phi.Message) {
+	switch m := message.(type) {
 	case MessageC:
-		return Response{msg: destC.name}
+		m.Responder <- Response{msg: destC.name}
 	default:
 		panic(fmt.Sprintf("unexpected message type %T", message))
 	}

--- a/examples/router/main.go
+++ b/examples/router/main.go
@@ -45,15 +45,15 @@ func main() {
 
 	// Send a message that should be routed to each of the three destinations.
 	var ok bool
-	_, ok = userTask.Send(MessageA{})
+	ok = userTask.Send(MessageA{Responder: make(chan phi.Message, 1)})
 	if !ok {
 		panic("could not send message to router")
 	}
-	_, ok = userTask.Send(MessageB{})
+	ok = userTask.Send(MessageB{Responder: make(chan phi.Message, 1)})
 	if !ok {
 		panic("could not send message to router")
 	}
-	_, ok = userTask.Send(MessageC{})
+	ok = userTask.Send(MessageC{Responder: make(chan phi.Message, 1)})
 	if !ok {
 		panic("could not send message to router")
 	}
@@ -65,7 +65,7 @@ func main() {
 			os.Exit(1)
 		}
 		return
-	case <-time.After(time.Second):
+	case <-time.After(10 * time.Second):
 		os.Exit(1)
 	}
 }

--- a/examples/router/main.go
+++ b/examples/router/main.go
@@ -65,7 +65,7 @@ func main() {
 			os.Exit(1)
 		}
 		return
-	case <-time.After(10 * time.Second):
+	case <-time.After(time.Second):
 		os.Exit(1)
 	}
 }

--- a/examples/router/message.go
+++ b/examples/router/message.go
@@ -1,19 +1,27 @@
 package main
 
+import "github.com/renproject/phi"
+
 // MessageA represents a message that has particular destination task.
-type MessageA struct{}
+type MessageA struct {
+	Responder chan phi.Message
+}
 
 // IsMessage implements the `phi.Message` interface.
 func (MessageA) IsMessage() {}
 
 // MessageB represents a message that has particular destination task.
-type MessageB struct{}
+type MessageB struct {
+	Responder chan phi.Message
+}
 
 // IsMessage implements the `phi.Message` interface.
 func (MessageB) IsMessage() {}
 
 // MessageC represents a message that has particular destination task.
-type MessageC struct{}
+type MessageC struct {
+	Responder chan phi.Message
+}
 
 // IsMessage implements the `phi.Message` interface.
 func (MessageC) IsMessage() {}

--- a/phi.go
+++ b/phi.go
@@ -25,8 +25,8 @@ type (
 	// Options is a struct re-exported from package `task`.
 	Options = task.Options
 
-	// Reducer is an interface re-exported from package `task`.
-	Reducer = task.Reducer
+	// Handler is an interface re-exported from package `task`.
+	Handler = task.Handler
 
 	// Router is an interface re-exported from package `task`.
 	Router = task.Router

--- a/task/task.go
+++ b/task/task.go
@@ -14,21 +14,11 @@ type Message interface {
 	IsMessage()
 }
 
-// messageWithResponder is a `Message` wrapper that also contains a channel
-// where a response can be written.
-type messageWithResponder struct {
-	// The message being sent.
-	message Message
-
-	// The responder channel where the task will write its response.
-	responder chan Messages
-}
-
-// Messages is a collection of messages. Note that reducers will never receive
+// Messages is a collection of messages. Note that handlers will never receive
 // a `Messages` type because they will always be flattened before being
 // processed. If a task needs to respond with more than one message, and it is
 // important that these messages are processed together, then a custom
-// container type should be created and handled appropriately in the reducer.
+// container type should be created and handled appropriately in the handler.
 type Messages []Message
 
 // IsMessage implements the Message interface.
@@ -43,25 +33,25 @@ type Runner interface {
 
 // Sender represents something that can be sent messages.
 type Sender interface {
-	// Send takes a message and returns a channel where the response will be
-	// written and also a boolean that indicates if the send was successful.
-	Send(Message) (<-chan Messages, bool)
+	// Send takes a message and returns a boolean that indicates if the send was
+	// successful.
+	Send(Message) bool
 }
 
 // Task is the intersection of the `Runner` and `Sender` interfaces. It
 // represents an entity that (when running) can be sent messages and upon
 // receipt of these messages performs internal logic (which often involves
-// sending messages to other tasks) and can also return response messages.
+// sending messages to other tasks).
 type Task interface {
 	Runner
 	Sender
 }
 
-// Reducer represents something that can receive a message and provide a
-// corresponding result. The `Task` argument is the parent task of the reducer,
-// and can be used as a handle to send messages to a reducer's own task.
-type Reducer interface {
-	Reduce(Task, Message) Message
+// Handler defines a type that can receive a message and mutate its internal
+// state. The `Task` argument is the parent task of the Handler, and can be used
+// by a Handler to send messages to itself.
+type Handler interface {
+	Handle(Task, Message)
 }
 
 // Router represents something that can route different messages to different
@@ -73,11 +63,11 @@ type Router interface {
 
 // Options are passed when constructing a `Task`. The `Cap` is the buffer
 // capacity of the `Task`'s channel, and the `Scale` is the number of worker
-// instances of the reducer for load balancing. If `Scale` is an number less
-// than 2, there will only be one instance of the reducer. It is important to
-// note that additional copies of the reducer will not be created for `Scale`
-// >= 2; this means that reducers that have and modify their own state are not
-// safe to be used at non-unity scales. Only reducers that are purely
+// instances of the handler for load balancing. If `Scale` is an number less
+// than 2, there will only be one instance of the handler. It is important to
+// note that additional copies of the handler will not be created for `Scale`
+// >= 2; this means that handlers that have and modify their own state are not
+// safe to be used at non-unity scales. Only handlers that are purely
 // functional should be used with non-unity scale.
 type Options struct {
 	Cap, Scale int
@@ -85,24 +75,24 @@ type Options struct {
 
 // task is a basic implementation for a `Task`.
 type task struct {
-	// The reducer for message handling logic.
-	reducer Reducer
+	// The handler for message handling logic.
+	handler Handler
 
 	// The buffered channel that incoming messages are written to.
-	input chan messageWithResponder
+	input chan Message
 
 	// The scale (number of workers) for the task.
 	scale int
 }
 
-// New returns a new task with the given reducer and buffer capacity. The
+// New returns a new task with the given handler and buffer capacity. The
 // buffer capacity is the number of messages that can be buffered for
 // processing before the task can no longer accept more messages (until space
 // in the buffer is freed up by processing messages in the buffer).
-func New(reducer Reducer, opts Options) Task {
+func New(handler Handler, opts Options) Task {
 	return &task{
-		reducer: reducer,
-		input:   make(chan messageWithResponder, opts.Cap),
+		handler: handler,
+		input:   make(chan Message, opts.Cap),
 		scale:   opts.Scale,
 	}
 }
@@ -117,8 +107,7 @@ func (task *task) Run(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case message := <-task.input:
-				message.responder <- task.reduce(flatten(message.message))
-				close(message.responder)
+				task.handle(flatten(message))
 			}
 		}
 	}
@@ -137,32 +126,26 @@ func (task *task) Run(ctx context.Context) {
 // true indicates the message was sent, and false indicates that the task
 // currently has a full buffer and won't accept the message. In the latter case
 // the returned channel will be nil.
-func (task *task) Send(message Message) (<-chan Messages, bool) {
-	responder := make(chan Messages, 1)
-	m := messageWithResponder{message: message, responder: responder}
+func (task *task) Send(m Message) bool {
 	select {
 	case task.input <- m:
-		return responder, true
+		return true
 	default:
-		return nil, false
+		return false
 	}
 }
 
-// reduce will handle the reduction of a given message for a task. It is
-// assumed that the message is flattened. It will always return a `Messages`
-// type which contains the responses of the reducer for the given message(s).
-// The returned `Messages` is flattened.
-func (task *task) reduce(message Message) Messages {
-	messages := Messages{}
-	switch message := message.(type) {
+// handle a message sent to the Task. It is assumed that the message is
+// flattened.
+func (task *task) handle(m Message) {
+	switch m := m.(type) {
 	case Messages:
-		for _, msg := range message {
-			messages = append(messages, task.reducer.Reduce(task, msg))
+		for _, msg := range m {
+			task.handler.Handle(task, msg)
 		}
 	default:
-		messages = append(messages, task.reducer.Reduce(task, message))
+		task.handler.Handle(task, m)
 	}
-	return flatten(messages).(Messages)
 }
 
 // flatten takes a message and effectively flattens it out to depth 1, where
@@ -208,7 +191,7 @@ func NewRouter(r Router) Sender {
 
 // Send implements the `Sender` interface. If the resolver returns a nil Sender,
 // it signifies that the message is not to be sent anywhere.
-func (r *router) Send(message Message) (<-chan Messages, bool) {
+func (r *router) Send(message Message) bool {
 	sender := func() Sender {
 		r.rMu.Lock()
 		defer r.rMu.Unlock()
@@ -217,5 +200,5 @@ func (r *router) Send(message Message) (<-chan Messages, bool) {
 	if sender != nil {
 		return sender.Send(message)
 	}
-	return nil, true
+	return true
 }

--- a/task/task.go
+++ b/task/task.go
@@ -124,8 +124,7 @@ func (task *task) Run(ctx context.Context) {
 // interface). It returns a channel to which the (possibly nil) response will
 // be written, and a bool indicating whether the message was able to be sent;
 // true indicates the message was sent, and false indicates that the task
-// currently has a full buffer and won't accept the message. In the latter case
-// the returned channel will be nil.
+// currently has a full buffer and won't accept the message.
 func (task *task) Send(m Message) bool {
 	select {
 	case task.input <- m:


### PR DESCRIPTION
This PR changes Phi to use asynchronous message passing (which can be used to simulate synchronous messages passing). The message senders and receivers are able to choose to message each other synchronously/asynchronously without affecting each other. For example: the message sender can decide to send synchronously, but the message receiver can respond asynchronously.

## Motivation

After using Phi in some larger projects, it has become obvious that the receiver of a message needs to be able to respond to the message asynchronously. By using the return value of the `Reduce` function as the response, we are forcing the receiver of a message to respond synchronously.

## Design

The change to asynchronous message passing is implemented with a couple minor changes:

- The `Reducer` interface is replaced with a `Handler` interface
- The `Reduce` method is replaced with a `Handle` method that is identical, except it does not return a `Message`
- The `Task` is updated to not expect messages back from a `Handler`

Synchronous message passing can be achieved by the caller explicitly injecting a `Responder chan<- T` channel into the `Message` being sent, and then block reading from this channel. This allows the caller to be synchronous, but the receiver can be synchronous or asynchronous.

## Testing

All examples have been updated to use this new model.